### PR TITLE
magicbot: Prefer variable annotation syntax

### DIFF
--- a/frameworks/magicbot.rst
+++ b/frameworks/magicbot.rst
@@ -95,24 +95,8 @@ Component creation
 ~~~~~~~~~~~~~~~~~~
 
 Components are instantiated by the MagicRobot class. You can tell the
-:class:`MagicRobot <robotpy_ext:magicbot.magicrobot.MagicRobot>` class to create
-magic components by defining the variable names and types in your MyRobot object.
-
-.. code-block:: python
-
-    from components import Elevator, Forklift
-
-    class MyRobot(MagicRobot):
-    
-        elevator = Elevator
-        forklift = Forklift
-        
-        def teleopPeriodic(self):
-            
-            # self.elevator is now an instance of Elevator
-
-You can also use Python 3.6 variable annotations to tell the MagicRobot class
-to create magic components:
+:class:`~magicbot.magicrobot.MagicRobot` class to create magic components
+by annotating the variable names and types in your MyRobot class.
 
 .. code-block:: python
 
@@ -123,7 +107,26 @@ to create magic components:
         forklift: Forklift
 
         def teleopPeriodic(self):
+            # self.elevator is now an instance of Elevator
+
+Note that the above uses variable annotations, introduced in Python 3.6.
+There is also an older syntax compatible with Python 3.5:
+
+.. code-block:: python
+
+    from components import Elevator, Forklift
+
+    class MyRobot(MagicRobot):
+        elevator = Elevator
+        forklift = Forklift
+
+        def teleopPeriodic(self):
             # self.elevator is an instance of Elevator
+
+Note that using this assignment syntax to declare magic components is considered
+to be deprecated, and will be removed once Python 3.5 support is dropped.
+This should only be important to your team if you're using Python 3.5 to
+develop your robot code.
 
 Variable injection
 ~~~~~~~~~~~~~~~~~~
@@ -136,24 +139,22 @@ out this example:
 .. code-block:: python
 
     class MyRobot(MagicRobot):
-        
-        elevator = Elevator
+        elevator: Elevator
     
         def createObjects(self):
             self.elevator_motor = wpilib.Talon(2)
     
     
     class Elevator:
-    
-        elevator_motor = wpilib.Talon
+        elevator_motor: wpilib.Talon
         
         def execute(self):
             # self.elevator_motor is a reference to the Talon instance
             # created in MyRobot.createObjects
 
-As you may be able to infer, by declaring in your ``Elevator`` class an attribute
+As you may be able to infer, by declaring in your ``Elevator`` class an annotation
 that matches an attribute in your Robot class, Magicbot automatically notices
-this and replaces the attribute in your component with the actual instance as
+this and adds an attribute in your component with the instance as
 defined in your robot class.
 
 Sometimes, it's useful to use multiple instances of the same class. You can
@@ -163,12 +164,10 @@ variable name:
 .. code-block:: python
 
     class MyRobot(MagicRobot):
-        
-        front_swerve = SwerveModule
-        back_swerve = SwerveModule
+        front_swerve: SwerveModule
+        back_swerve: SwerveModule
         
         def createObjects(self):
-            
             # this is injected into the front_swerve instance of SwerveModule as 'motor'
             self.front_swerve_motor = wpilib.Talon(1)
             
@@ -176,7 +175,7 @@ variable name:
             self.back_swerve_motor = wpilib.Talon(2)
             
     class SwerveModule:
-        motor = wpilib.Talon
+        motor: wpilib.Talon
 
 One problem that sometimes comes up is your component may require a lot of
 configuration parameters. Remember, anything can be injected: integers, numbers,
@@ -191,31 +190,34 @@ are readonly):
 
     class MyRobot(MagicRobot):
         
-        shooter = Shooter
+        shooter: Shooter
         shooter_cfg = ShooterConfig(param1=1, param2=2, param3=3)
         
     class Shooter:
-        cfg = ShooterConfig
+        cfg: ShooterConfig
         
         def execute(self):
             # you can access self.cfg.param1, self.cfg.param2, etc...
 
-Like component creation, you can alternatively use Python 3.6 variable
-annotations to declare variables to be injected:
+Like component creation, there is a Python 3.5 compatible syntax that uses
+assignment to declare variables to be injected:
 
 .. code-block:: python
 
     class Elevator:
-        motor: wpilib.Talon
+        motor = wpilib.Talon
 
         def execute(self):
             # self.motor is the Talon instance created in MyRobot.createObjects
 
     class MyRobot(MagicRobot):
-        elevator: Elevator
+        elevator = Elevator
 
         def createObjects(self):
             self.elevator_motor = wpilib.Talon(1)
+
+This syntax is similarly deprecated and will be removed once Python 3.5 support
+is dropped.
 
 Variable injection in magicbot is one of its most useful features, take
 advantage of it in creative ways!
@@ -294,7 +296,7 @@ are easier to reason about.
 
 Here's an example autonomous mode that drives straight for 3 seconds.
 
-::
+.. code-block:: python
 
     from magicbot import AutonomousStateMachine, timed_state, state
     import wpilib
@@ -308,7 +310,7 @@ Here's an example autonomous mode that drives straight for 3 seconds.
         DEFAULT = True
 
         # Injected from the definition in robot.py
-        drivetrain = DriveTrain
+        drivetrain: DriveTrain
 
         @timed_state(duration=3, first=True)
         def drive_forward(self):
@@ -344,7 +346,7 @@ In the following example, this would create a NetworkTables variable called
     ...
 
     class MyRobot:
-        mine = MyComponent
+        mine: MyComponent
 
 To access the variable, in ``MyComponent`` you can read or write ``self.foo``
 and it will read/write to NetworkTables.
@@ -369,8 +371,7 @@ bypass any automation and more easily test the component.
 Here's an example single-wheel shooter component::
 
     class Shooter:
-
-        shooter_motor = wpilib.Talon
+        shooter_motor: wpilib.Talon
         
         # speed is tunable via NetworkTables
         shoot_speed = tunable(1.0)
@@ -417,9 +418,9 @@ Let's automate these two using a state machine helper::
     from magicbot import StateMachine, state, timed_state
 
     class ShooterControl(StateMachine):
-        shooter = Shooter
-        intake = Intake
-        
+        shooter: Shooter
+        intake: Intake
+
         def fire(self):
             '''This function is called from teleop or autonomous to cause the
                shooter to fire'''
@@ -473,16 +474,15 @@ Here's one way that you might put them together in your robot.py file::
     class MyRobot(magicbot.MagicRobot):
 
         # High level components go first
-        shooter_control = ShooterControl
+        shooter_control: ShooterControl
 
         # Low level components come last
-        intake = Intake
-        shooter = Shooter
-        
+        intake: Intake
+        shooter: Shooter
+
         ...
-        
+
         def teleopPeriodic(self):
-        
             if self.joystick.getTrigger():
                 self.shooter_control.fire()
 


### PR DESCRIPTION
This deprecates the old assignment syntax for declaring components and
injectables, with the intention of removing it after dropping Python
3.5 support.