### PR TITLE
Add link to PyFRC physics API documentation

### DIFF
--- a/guide/simulator.rst
+++ b/guide/simulator.rst
@@ -37,7 +37,7 @@ for early testing of autonomous movements.
    easier than it sounds!). Helper functions are provided to calculate robot
    position for common drivetrain types (see below for details). There are
    physics examples provided in the `RobotPy Examples Repository <https://github.com/robotpy/examples>`_
-   for each supported drivetrain type.
+   for each supported drivetrain type, and the PyFRC Physics API documentation is `here <https://robotpy.readthedocs.io/projects/pyfrc/en/stable/physics.html>`_.
 
 ..  Adding custom tooltips to motors/sensors (doesn't work in 2015!)
 	


### PR DESCRIPTION
In this guide, it is helpful to link the physics API documentation to make it easier for newer users (such as myself) to locate.

I tried using the :ref: syntax since the page is in the same manual, but I couldn't figure it out. Feel free to fix this if you know how.