### PR TITLE
Remove cscore notice about binary packages

### DIFF
--- a/vision/other.rst
+++ b/vision/other.rst
@@ -3,9 +3,7 @@ Other platforms
 ===============
 
 ``robotpy-cscore`` is a great solution for running image processing on a
-coprocessor such as the Raspberry Pi or on the Driver Station. However, we 
-do not provide precompiled packages at this time and you will need to compile
-binary packages for your platform.
+coprocessor such as the Raspberry Pi or on the Driver Station.
 
 Installation
 ------------


### PR DESCRIPTION
According to https://robotpy.readthedocs.io/en/latest/install/cscore.html#install-cscore binary packages ARE distributed now.